### PR TITLE
[UrlSafe] Make the urls generated by Dragonfly urlsafe

### DIFF
--- a/lib/dragonfly/serializer.rb
+++ b/lib/dragonfly/serializer.rb
@@ -10,12 +10,11 @@ module Dragonfly
     extend self # So we can do Serializer.b64_encode, etc.
     
     def b64_encode(string)
-      Base64.encode64(string).tr("\n=",'')
+      Base64.urlsafe_encode64(string)
     end
     
     def b64_decode(string)
-      padding_length = string.length % 4
-      Base64.decode64(string + '=' * padding_length)
+      Base64.urlsafe_decode64(string)
     end
     
     def marshal_encode(object)

--- a/spec/dragonfly/serializer_spec.rb
+++ b/spec/dragonfly/serializer_spec.rb
@@ -14,7 +14,7 @@ describe Dragonfly::Serializer do
     '£ñçùí;'
   ].each do |string|
     it "should encode #{string.inspect} properly with no padding/line break" do
-      b64_encode(string).should_not =~ /\n|=/
+      b64_encode(string).should_not =~ /\//
     end
     it "should correctly encode and decode #{string.inspect} to the same string" do
       str = b64_decode(b64_encode(string))


### PR DESCRIPTION
### Description

In Dragonfly a Job object represents a chained sequence of commands, e.g.

```ruby
image = Dragonfly.app.fetch('2008/dog.png').thumb('300x300')
```

represents the steps

* fetch the content with uid “2008/dog.png” from the datastore
* process this content with the registered “thumb” processor

Calling a `.url` on the job, returns a url that's is essentially `Base64` encoded of the sequence of steps.

E.g `url` for the above `job` is 
```ruby
image.url   # ===> "/W1siZiIsIjIwMDgvZG9nLnBuZyJdLFsicCIsInRodW1iIiwiMzAweDMwMCJdXQ"
```

This cause problem for certain urls that are not `url_safe`. E.g `/clipart/assets/images/BAhbB1sHOgZmIiAzMjc2NDdfSnVuMTMyMDE5VGh1MDM0OTA5UE1bCDoGcDoOdGh1bWJuYWlsWwppe1RGaQBpA9//BA`

In the ☝️ above example `//` in the url gets escaped to `/` when the url gets to the app sever.

https://ruby-doc.org/stdlib-2.4.0/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_encode64
```
Base 64 Encoding with URL and Filename Safe Alphabet'' in RFC 4648. The alphabet uses '-' instead of '+' and '_' instead of '/'
```
### Changes

Use `urlsafe_encode64` & `urlsafe_decode64` for encoding & decoding of processing steps.
